### PR TITLE
chore: add PR template, CODEOWNERS, and workflow setup

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @irizclaire1

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,49 @@
+# 📄 Pull Request Title
+<!-- Example: Add Login Page UI and Functionality -->
+
+---
+
+# 🛠 Description
+<!-- 
+Describe WHAT you did and WHY.
+Example:
+- Implemented login page UI.
+- Integrated Firebase Authentication.
+- Added validation for email/password.
+ -->
+
+---
+
+# 🔗 Related Task / Issue
+<!-- 
+Link tasks/issues here.
+Example:
+- Task: [Login Page Implementation](https://your-task-link.com)
+- Issue: #123
+ -->
+
+---
+
+# 🧪 Testing
+<!-- 
+Explain how you tested it.
+Example:
+- Tested login with valid/invalid credentials.
+- Confirmed error messages and success flow.
+ -->
+
+---
+
+# ✅ Checklist
+- [ ] Code is properly formatted.
+- [ ] Changes tested thoroughly.
+- [ ] No console errors/warnings.
+- [ ] Branch is up-to-date with `develop`.
+- [ ] No merge conflicts.
+
+---
+
+# 👩‍💻 Reviewer
+Assigned Reviewer: @irizclaire1
+
+---

--- a/.github/workflows/label-prs.yml
+++ b/.github/workflows/label-prs.yml
@@ -1,0 +1,16 @@
+name: Label PRs Automatically
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+jobs:
+  add-label:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Add label to Pull Request
+        uses: actions-ecosystem/action-add-labels@v1
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          labels: |
+            needs review

--- a/.github/workflows/label-prs.yml
+++ b/.github/workflows/label-prs.yml
@@ -7,6 +7,8 @@ on:
 jobs:
   add-label:
     runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write   
     steps:
       - name: Add label to Pull Request
         uses: actions-ecosystem/action-add-labels@v1


### PR DESCRIPTION
# 📄 Description
- Added `.github/` folder for better project management.
- Included a **PULL_REQUEST_TEMPLATE.md** to standardize PR descriptions.
- Added a **CODEOWNERS** file to auto-assign reviewers to PRs.
- Set up **GitHub Actions workflow** for automatic PR labeling (`needs review`).

# 🔗 Related Issue
- N/A (This is a setup task)

# 🧪 Testing
- Ensure that the **PULL_REQUEST_TEMPLATE.md** automatically appears when creating a PR.
- Check that the **CODEOWNERS** file assigns the correct reviewer.
- Confirm that PRs are automatically labeled with `needs review`.

# ✅ Checklist
- [x] `.github/` folder successfully added.
- [x] PR template is working correctly.
- [x] Reviewer is automatically assigned using `CODEOWNERS`.
- [x] PR label `needs review` is added automatically.